### PR TITLE
Don't use the seed in the .lck filename

### DIFF
--- a/lib/lockfile.rb
+++ b/lib/lockfile.rb
@@ -467,13 +467,13 @@ unless(defined?($__lockfile__) or defined?(Lockfile))
       lock_id
     end
 
-    def tmpnam(dir, seed = File.basename($0))
+    def tmpnam(dir)
       pid = Process.pid
       time = Time.now
       sec = time.to_i
       usec = time.usec
-      "%s%s.%s_%d_%s_%d_%d_%d.lck" % 
-        [dir, File::SEPARATOR, HOSTNAME, pid, seed, sec, usec, rand(sec)]
+      "%s%s.%s_%d_%d_%d_%d.lck" % 
+        [dir, File::SEPARATOR, HOSTNAME, pid, sec, usec, rand(sec)]
     end
 
     def create(path)


### PR DESCRIPTION
We were experiencing errors that looked like:

```
File name too long -
/var/www/vhosts/silo/releases/20131002182809/tmp/dynamic_proxies/.silo-work29_8354_resque-1.19.0:
Waiting for
realtime_alf_serp_collector,high_priority_event_publisher,high_priority,realtime_alf_poster,normal_historical_rankings_collector,serp_deindexer,document_indexer,serp_churn_scrapeable_1380840273_497203_1335935188.lck
```

The cause of this is the `seed`.  Since the .lck file already has the PID in it, adding the seed
does not add to the "uniqueness" of the filename, but is adding to the length of the filename (which
is causing us issues).
