### PR TITLE
Explicitly declare a Ruby license

### DIFF
--- a/lockfile.gemspec
+++ b/lockfile.gemspec
@@ -23,4 +23,5 @@ Gem::Specification::new do |spec|
   spec.author = "Ara T. Howard"
   spec.email = "ara.t.howard@gmail.com"
   spec.homepage = "http://github.com/ahoward/lockfile/tree/master"
+  spec.license = "Ruby"
 end


### PR DESCRIPTION
Rather than relying on an external license reference, update the gemspec to contain the proper license indicator.
